### PR TITLE
New method of generating ```DiGraph``` and organizing node data

### DIFF
--- a/stormcatchments/delineate.py
+++ b/stormcatchments/delineate.py
@@ -145,7 +145,7 @@ class Delineate:
         continue
       else:
         delineated_oids.add(pt.Index)
-        x, y = self.net.get_point_coords(pt)
+        x, y = net.get_point_coords(pt)
         pt_catchment = self.get_catchment((x, y))
         catchments = catchments.append(pt_catchment)
 
@@ -174,7 +174,7 @@ class Delineate:
       A GeoDataFrame containing the newly delineated catchment polygon
     '''
     catchment = self.get_catchment(pour_pt, acc_thresh)
-    self.net.generate_catchment_graphs(catchment)
+    self.net.resolve_catchment_graph(catchment)
 
     delineated_oids = set()
 

--- a/stormcatchments/delineate.py
+++ b/stormcatchments/delineate.py
@@ -114,7 +114,7 @@ class Delineate:
     return get_catchment(pour_pt, self.grid, self.fdir, self.acc, self.grid_epsg)
 
   def delineate_points(
-    self, pts: gpd.GeoDataFrame, delineated_oids: set
+    self, pts: gpd.GeoDataFrame, delineated: set
   ) -> tuple([gpd.GeoDataFrame, set]):
     '''
     Delineate catchments for a subset of infrastructure points
@@ -140,19 +140,20 @@ class Delineate:
     '''
     catchments = gpd.GeoDataFrame()
 
-    for pt in pts.itertuples():
-      if pt.Index in delineated_oids:
+    for pt in pts.itertuples(name='StormPoint'):
+      if pt.Index in delineated:
         continue
       else:
-        delineated_oids.add(pt.Index)
-        x, y = net.get_point_coords(pt)
+        delineated.add(pt.Index)
+        x = pt.geometry.x
+        y = pt.geometry.y
         pt_catchment = self.get_catchment((x, y))
         catchments = catchments.append(pt_catchment)
 
     if not catchments.empty:
       catchments = catchments.set_crs(epsg=self.grid_epsg)
 
-    return catchments, delineated_oids
+    return catchments, delineated
 
 
   def get_stormcatchment(self, pour_pt: tuple, acc_thresh: int=1000) -> gpd.GeoDataFrame:
@@ -176,13 +177,14 @@ class Delineate:
     catchment = self.get_catchment(pour_pt, acc_thresh)
     self.net.resolve_catchment_graph(catchment)
 
-    delineated_oids = set()
+    # Keep track of all point indicies which have been delineated
+    delineated = set()
 
     while True:
       outlet_pts = self.net.get_outlet_points(catchment)
       if not outlet_pts.empty:
-        outlet_catchments, delineated_oids = self.delineate_points(
-          outlet_pts, delineated_oids
+        outlet_catchments, delineated = self.delineate_points(
+          outlet_pts, delineated
         )
         if not outlet_catchments.empty:
           catchment = gpd.overlay(
@@ -195,15 +197,15 @@ class Delineate:
 
       inlet_pts = self.net.get_inlet_points(catchment)
       if not inlet_pts.empty:
-        inlet_catchments, delineated_oids = self.delineate_points(
-          inlet_pts, delineated_oids
+        inlet_catchments, delineated = self.delineate_points(
+          inlet_pts, delineated
         )
         if not inlet_catchments.empty:
           catchment = gpd.overlay(
             catchment, inlet_catchments, how='union'
           ).set_crs(epsg=self.grid_epsg)
           catchment = catchment.dissolve()
-          self.net.generate_catchment_graphs(catchment)
+          self.net.resolve_catchment_graph(catchment)
         else:
           # empty inlet_pts
           inlet_pts = gpd.GeoDataFrame()

--- a/tests/test_delineate.py
+++ b/tests/test_delineate.py
@@ -1,5 +1,5 @@
 import geopandas as gpd
-from pysheds.grid import Grid
+from shapely.geometry import Point
 import pytest
 
 from stormcatchments import network, delineate, terrain
@@ -17,10 +17,21 @@ def delineate_johnson():
   return delineate.Delineate(net, grid, fdir, acc, 6589)
 
 def test_get_catchment(delineate_johnson):
+  delin = delineate_johnson
   pour_pt = (484636, 237170)
-  catchment = delineate_johnson.get_catchment(pour_pt)
+  catchment = delin.get_catchment(pour_pt)
   assert round(catchment.area.values[0], 1) == 6796.3
 
 def test_get_stormcatchment(delineate_johnson):
+  delin = delineate_johnson
   pour_pt = (484636, 237170)
-  stormcatchment = delineate_johnson.get_stormcatchment(pour_pt)
+  stormcatchment = delin.get_stormcatchment(pour_pt)
+  stormcatchment_geom = stormcatchment.iloc[0].geometry
+
+  contain_coords = [(484700, 237490), (484696, 237272)]
+  for coords in contain_coords:
+    assert stormcatchment_geom.contains(Point(coords))
+
+  not_contain_coords = [(484590, 237200), (484750, 237330)]
+  for coords in not_contain_coords:
+    assert not stormcatchment_geom.contains(Point(coords))

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -12,57 +12,80 @@ def net_johnson():
   return net
 
 
-def test_add_upstream_simple_johnson(net_johnson):
-  downstream_pt = net_johnson.pts.loc[244244]
-  net_johnson.add_upstream_pts(downstream_pt)
-  assert len(net_johnson.G.nodes()) == 3
+def test_init_johnson(net_johnson):
+  '''Ensure Network initialization generates non-empty graph'''
+  net = net_johnson
+  assert not net.segments.empty
+  assert net.G.number_of_nodes() > 0
 
 
-def test_add_upstream_complex_johnson(net_johnson):
-  downstream_pt = net_johnson.pts.loc[21134]
-  net_johnson.add_upstream_pts(downstream_pt)
-
-  # Ensure correct number of nodes are present
-  assert len(net_johnson.G.nodes()) == 34
-
-  # Ensure all node coordinates are unique
-  coords = set()
-  for _, pt in nx.get_node_attributes(net_johnson.G, 'geometry').items():
-    assert (pt.x, pt.y) not in coords, 'Graph has a duplicate coordinate'
-    coords.add((pt.x, pt.y))
+def test_points_in_graph_johnson(net_johnson):
+  '''Ensure coordinates of various storm_points are present as nodes within the graph'''
+  net = net_johnson
+  for idx in [20845, 244244, 21135, 244947, 244275]:
+    x, y = network.get_point_coords(net.pts.loc[idx].geometry)
+    assert net.G.has_node((x, y))
 
 
-def test_add_upstream_twice_johnson(net_johnson):
-  # 3 nodes
-  downstream_pt = net_johnson.pts.loc[244244]
-  net_johnson.add_upstream_pts(downstream_pt)
+def test_resolve_direction_simple_johnson(net_johnson):
+  '''
+  Ensure the direction of a simple 3-node subgraph can be resolved such that the only
+  edges present are in the correct direction of flow for that subgraph
+  '''
+  net = net_johnson
+  outfall_pt = net.pts.loc[244244]
+  net.resolve_direction(outfall_pt)
 
-  # 5 nodes, disconnected from previous subgraph
-  downstream_pt = net_johnson.pts.loc[244153]
-  net_johnson.add_upstream_pts(downstream_pt)
+  edges = {244374: 244244, 244900: 244374}
+  for u, v in edges.items():
+    u_x, u_y = network.get_point_coords(net.pts.loc[u].geometry)
+    v_x, v_y = network.get_point_coords(net.pts.loc[v].geometry)
+    # Edge is present in correct direction of flow
+    assert net.G.has_edge((u_x, u_y), (v_x, v_y))
+    # Edge is not present in reverse of flow direction
+    assert not net.G.has_edge((v_x, v_y), (u_x, u_y))
 
-  assert len(net_johnson.G.nodes()) == 8
+
+def test_resolve_direction_complex_johnson(net_johnson):
+  '''
+  Ensure the direction of a larger subgraph with multiple branches can be resolved such
+  that the only edges present are in the correct direction of flow for that subgraph
+  '''
+  net = net_johnson
+  outfall_pt = net.pts.loc[21134]
+  net.resolve_direction(outfall_pt)
+  
+  edges = {20845: 21134, 20846: 20845, 20847: 20846, 21135: 20845}
+  for u, v in edges.items():
+    u_x, u_y = network.get_point_coords(net.pts.loc[u].geometry)
+    v_x, v_y = network.get_point_coords(net.pts.loc[v].geometry)
+    # Edge is present in correct direction of flow
+    assert net.G.has_edge((u_x, u_y), (v_x, v_y))
+    # Edge is not present in reverse of flow direction
+    assert not net.G.has_edge((v_x, v_y), (u_x, u_y))
 
 
 def test_get_outlet_johnson(net_johnson):
-  downstream_pt = net_johnson.pts.loc[21134]
-  net_johnson.add_upstream_pts(downstream_pt)
-  assert net_johnson.get_outlet(20847) == 21134
+  net = net_johnson
+  outfall_pt = net.pts.loc[21134]
+  net.resolve_direction(outfall_pt)
+  assert net.get_outlet(20847) == 21134
 
 
 def test_find_downstream_simple_johnson(net_johnson):
-  upstream_pt = net_johnson.pts.loc[245051]
-  downstream_pt = net_johnson.find_downstream_pt(upstream_pt)
+  net = net_johnson
+  upstream_pt = net.pts.loc[245051]
+  downstream_pt = net.find_downstream_pt(upstream_pt)
   assert downstream_pt.Index == 244132
 
 
-def test_generate_catchment_graphs_johnson(net_johnson):
-  initial_catchment = gpd.read_file('tests/test_data/johnson_vt/initial_catchment.shp')
-  net_johnson.generate_catchment_graphs(initial_catchment['geometry'])
-  pt_types = [
-    pt_type for _, pt_type in nx.get_node_attributes(net_johnson.G, 'Type').items()
-  ]
-  # 3 catchbasins
-  assert pt_types.count(2) == 3
-  # 3 culvert outlets
-  assert pt_types.count(9) == 3
+# def test_generate_catchment_graphs_johnson(net_johnson):
+#   initial_catchment = gpd.read_file('tests/test_data/johnson_vt/initial_catchment.shp')
+#   net_johnson.generate_catchment_graphs(initial_catchment['geometry'])
+#   pt_types = [
+#     pt_type for _, pt_type in nx.get_node_attributes(net_johnson.G, 'Type').items()
+#   ]
+#   # 3 catchbasins
+#   assert pt_types.count(2) == 3
+#   # 3 culvert outlets
+#   assert pt_types.count(9) == 3


### PR DESCRIPTION
This process for generating ```network.Network.G``` is much simpler than the earlier method. It differs in that:
- The graph is fully initialized for every line vertex upon initialization of ```network.Network```, but all edges start as bidirectional
- Nodes in ```network.Network.G``` are indexed by coordinate tuples
- Attribute data for each point is not copied into ```network.Network.G```

Other changes:
- Coordinates are optionally rounded to a specified decimal point, with the default being 3 decimals points