### PR TITLE
setup.py: Fix `extras_require` keyword

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     'pysheds',
     'rtree'
   ],
-  extra_requires={
+  extras_require={
     'basemap': 'contextily',
     'dev': [
       'pytest'


### PR DESCRIPTION
This PR fixes the installation of optional dependencies. The correct keyword for optional dependencies for setuptools is `extras_require` (instead of `extra_requires`).