### PR TITLE
CI: Create initial GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Python 3.11 supported is blocked by Numba: https://github.com/numba/numba/issues/8304
+        python-version: ["3.10"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "3.8"
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: pip install .[dev]
+    - name: Test with Pytest
+      run: pytest


### PR DESCRIPTION
Create an initial GitHub Actions CI workflow which runs the tests with pytest on different Python versions.

Here's an [example run](https://github.com/EwoutH/stormcatchments/actions/runs/3591004707) from my fork. As you [can see](https://github.com/EwoutH/stormcatchments/actions/runs/3591004707/jobs/6045031599#step:5:20), it already catches some errors, warnings and deprecations!