### PR TITLE
setup.py: Require Python 3.8 of higher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setup(
     'Programming Language :: Python :: 3.9',
     'Topic :: Scientific/Engineering :: GIS',
     'Topic :: Scientific/Engineering :: Hydrology'
-  ]
+  ],
+  python_requires='>=3.8'
 )


### PR DESCRIPTION
Specify `python_requires` in `setup.py`, so setuptools, pip and other tools know at least Python 3.8 is required for future releases. Python 3.8 is chosen in line with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html), which a large part of the scientific community follows. Python 3.8 and higher is also tested in CI.